### PR TITLE
Move from observation delay to action delay

### DIFF
--- a/footsiesgym/__init__.py
+++ b/footsiesgym/__init__.py
@@ -40,10 +40,10 @@ def make(config: dict | None = None, platform: str = "linux", launch_binaries: b
     default_config = {
         "platform": platform, 
         "launch_binaries": launch_binaries,
-        "max_t": 4000,
+        "max_t": 1000,
         "frame_skip": 4,
-        "observation_delay": 16,
-        "guard_break_reward": 0.005,
+        "action_delay": 8,
+        "guard_break_reward": 0.0,
     }
 
     if config is not None:

--- a/footsiesgym/__init__.py
+++ b/footsiesgym/__init__.py
@@ -11,7 +11,7 @@ from .footsies.footsies_env import FootsiesEnv
 from .footsies import encoder, typing
 from .binary_manager import get_binary_manager
 
-__version__ = "0.1.7"
+__version__ = "0.2.0"
 __all__ = ["FootsiesEnv", "encoder", "typing", "make"]
 
 # Initialize binary manager (but don't download yet - wait until needed)

--- a/footsiesgym/__init__.py
+++ b/footsiesgym/__init__.py
@@ -11,7 +11,7 @@ from .footsies.footsies_env import FootsiesEnv
 from .footsies import encoder, typing
 from .binary_manager import get_binary_manager
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = ["FootsiesEnv", "encoder", "typing", "make"]
 
 # Initialize binary manager (but don't download yet - wait until needed)

--- a/footsiesgym/__init__.py
+++ b/footsiesgym/__init__.py
@@ -11,7 +11,7 @@ from .footsies.footsies_env import FootsiesEnv
 from .footsies import encoder, typing
 from .binary_manager import get_binary_manager
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __all__ = ["FootsiesEnv", "encoder", "typing", "make"]
 
 # Initialize binary manager (but don't download yet - wait until needed)

--- a/footsiesgym/__init__.py
+++ b/footsiesgym/__init__.py
@@ -11,7 +11,7 @@ from .footsies.footsies_env import FootsiesEnv
 from .footsies import encoder, typing
 from .binary_manager import get_binary_manager
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 __all__ = ["FootsiesEnv", "encoder", "typing", "make"]
 
 # Initialize binary manager (but don't download yet - wait until needed)

--- a/footsiesgym/__init__.py
+++ b/footsiesgym/__init__.py
@@ -11,7 +11,7 @@ from .footsies.footsies_env import FootsiesEnv
 from .footsies import encoder, typing
 from .binary_manager import get_binary_manager
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __all__ = ["FootsiesEnv", "encoder", "typing", "make"]
 
 # Initialize binary manager (but don't download yet - wait until needed)

--- a/footsiesgym/__init__.py
+++ b/footsiesgym/__init__.py
@@ -11,7 +11,7 @@ from .footsies.footsies_env import FootsiesEnv
 from .footsies import encoder, typing
 from .binary_manager import get_binary_manager
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __all__ = ["FootsiesEnv", "encoder", "typing", "make"]
 
 # Initialize binary manager (but don't download yet - wait until needed)

--- a/footsiesgym/binary_manager.py
+++ b/footsiesgym/binary_manager.py
@@ -274,7 +274,7 @@ class BinaryManager:
                 
                 # Create request with user agent to avoid blocking
                 request = urllib.request.Request(url)
-                request.add_header('User-Agent', 'FootsiesGym/0.2.1')
+                request.add_header('User-Agent', 'FootsiesGym/0.2.2')
                 
                 with urllib.request.urlopen(request, timeout=30) as response:
                     # Check if we got a valid response

--- a/footsiesgym/binary_manager.py
+++ b/footsiesgym/binary_manager.py
@@ -274,7 +274,7 @@ class BinaryManager:
                 
                 # Create request with user agent to avoid blocking
                 request = urllib.request.Request(url)
-                request.add_header('User-Agent', 'FootsiesGym/0.2.0')
+                request.add_header('User-Agent', 'FootsiesGym/0.2.1')
                 
                 with urllib.request.urlopen(request, timeout=30) as response:
                     # Check if we got a valid response

--- a/footsiesgym/binary_manager.py
+++ b/footsiesgym/binary_manager.py
@@ -274,7 +274,7 @@ class BinaryManager:
                 
                 # Create request with user agent to avoid blocking
                 request = urllib.request.Request(url)
-                request.add_header('User-Agent', 'FootsiesGym/0.2.2')
+                request.add_header('User-Agent', 'FootsiesGym/0.2.3')
                 
                 with urllib.request.urlopen(request, timeout=30) as response:
                     # Check if we got a valid response

--- a/footsiesgym/binary_manager.py
+++ b/footsiesgym/binary_manager.py
@@ -274,7 +274,7 @@ class BinaryManager:
                 
                 # Create request with user agent to avoid blocking
                 request = urllib.request.Request(url)
-                request.add_header('User-Agent', 'FootsiesGym/0.2.4')
+                request.add_header('User-Agent', 'FootsiesGym/0.2.5')
                 
                 with urllib.request.urlopen(request, timeout=30) as response:
                     # Check if we got a valid response

--- a/footsiesgym/binary_manager.py
+++ b/footsiesgym/binary_manager.py
@@ -274,7 +274,7 @@ class BinaryManager:
                 
                 # Create request with user agent to avoid blocking
                 request = urllib.request.Request(url)
-                request.add_header('User-Agent', 'FootsiesGym/0.1.7')
+                request.add_header('User-Agent', 'FootsiesGym/0.2.0')
                 
                 with urllib.request.urlopen(request, timeout=30) as response:
                     # Check if we got a valid response

--- a/footsiesgym/binary_manager.py
+++ b/footsiesgym/binary_manager.py
@@ -274,7 +274,7 @@ class BinaryManager:
                 
                 # Create request with user agent to avoid blocking
                 request = urllib.request.Request(url)
-                request.add_header('User-Agent', 'FootsiesGym/0.2.3')
+                request.add_header('User-Agent', 'FootsiesGym/0.2.4')
                 
                 with urllib.request.urlopen(request, timeout=30) as response:
                     # Check if we got a valid response

--- a/footsiesgym/footsies/encoder.py
+++ b/footsiesgym/footsies/encoder.py
@@ -188,8 +188,6 @@ class FootsiesEncoder:
             ),
         }
 
-        print(feature_dict["special_attack_progress"])
-
         if kwargs:
             feature_dict.update(kwargs)
 

--- a/footsiesgym/footsies/encoder.py
+++ b/footsiesgym/footsies/encoder.py
@@ -7,6 +7,22 @@ import numpy as np
 from footsiesgym.footsies.game import constants
 from footsiesgym.footsies.game.proto import footsies_service_pb2 as footsies_pb2
 
+import dataclasses
+
+@dataclasses.dataclass
+class NormalizationConstants:
+    stage_width: float = 8.0
+    max_x_value: float = 4.0
+    meaningful_velocity_x: float = 5.0
+    meaningful_frame_count: float = 25.0
+    meaningful_sprite_shake_frame: float = 10.0
+    meaningful_hit_stun_frame: float = 10.0
+    meaningful_frame_advantage: float = 10.0
+    meaningful_special_attack_progress: float = 1.0
+    meaningful_guard_health: float = 3.0
+    meaningful_vital_health: float = 1.0
+    
+
 
 class EncoderMethods:
     @staticmethod
@@ -21,7 +37,8 @@ class EncoderMethods:
 class FootsiesEncoder:
     """Encoder class to generate observations from the game state"""
 
-    observation_size: int = 81
+    observation_size: int = 78
+    privileged_feature_names: list[str] = ["special_attack_progress", "would_next_forward_input_dash", "would_next_backward_input_dash"]
 
     def __init__(self):
         self._last_common_state: np.ndarray | None = None
@@ -59,27 +76,28 @@ class FootsiesEncoder:
 
         self._last_common_state = common_state
 
-        # Create features dictionary and export to JSON
-        features = {}
-        current_index = 0
-
-        # Common state
-        features["common_state"] = {
-            "start": current_index,
-            "length": len(common_state),
-        }
-        current_index += len(common_state)
-
         # Concatenate the observations for the undelayed encoding
-        p1_encoding = np.hstack(list(p1_encoding.values()), dtype=np.float32)
-        p2_encoding = np.hstack(list(p2_encoding.values()), dtype=np.float32)
+        p1_encoding_concat = np.hstack(list(p1_encoding.values()), dtype=np.float32)
+        p2_encoding_concat = np.hstack(list(p2_encoding.values()), dtype=np.float32)
+
+        # Opponent states that remove privileged features
+        # Remove privileged features from the opponent's state dict then concatenate
+        p1_opponent_state = np.hstack(
+            [p2_encoding[key] for key in p2_encoding if key not in self.privileged_feature_names],
+            dtype=np.float32,
+        )
+        p2_opponent_state = np.hstack(
+            [p1_encoding[key] for key in p1_encoding if key not in self.privileged_feature_names],
+            dtype=np.float32,
+        )
+
 
         p1_centric_observation = np.hstack(
-            [common_state, p1_encoding, p2_encoding]
+            [common_state, p1_encoding_concat, p2_opponent_state]
         )
 
         p2_centric_observation = np.hstack(
-            [common_state, p2_encoding, p1_encoding]
+            [common_state, p2_encoding_concat, p1_opponent_state]
         )
 
         return {"p1": p1_centric_observation, "p2": p2_centric_observation}
@@ -102,7 +120,7 @@ class FootsiesEncoder:
 
         dist_x = (
             np.abs(p1_state.player_position_x - p2_state.player_position_x)
-            / 8.0
+            / NormalizationConstants.stage_width
         )
 
         return np.array(
@@ -130,8 +148,8 @@ class FootsiesEncoder:
         TODO(chase): Make normalizing constants set in a constants class. 
         """
         feature_dict = {
-            "player_position_x": player_state.player_position_x / 4.0,
-            "velocity_x": player_state.velocity_x / 5.0,
+            "player_position_x": player_state.player_position_x / NormalizationConstants.max_x_value,
+            "velocity_x": player_state.velocity_x / NormalizationConstants.meaningful_velocity_x,
             "is_dead": int(player_state.is_dead),
             "vital_health": player_state.vital_health,
             "guard_health": EncoderMethods.one_hot(
@@ -140,25 +158,26 @@ class FootsiesEncoder:
             "current_action_id": self._encode_action_id(
                 player_state.current_action_id
             ),
-            "current_action_frame": player_state.current_action_frame / 25,
+            "current_action_frame": player_state.current_action_frame / NormalizationConstants.meaningful_frame_count,
             "current_action_frame_count": player_state.current_action_frame_count
-            / 25,
+            / NormalizationConstants.meaningful_frame_count,
             "current_action_remaining_frames": (
                 player_state.current_action_frame_count
                 - player_state.current_action_frame
             )
-            / 25,
+            / NormalizationConstants.meaningful_frame_count,
             "is_action_end": int(player_state.is_action_end),
             "is_always_cancelable": int(player_state.is_always_cancelable),
             "current_action_hit_count": player_state.current_action_hit_count,
-            "current_hit_stun_frame": player_state.current_hit_stun_frame / 10,
+            "current_hit_stun_frame": player_state.current_hit_stun_frame / NormalizationConstants.meaningful_hit_stun_frame,
             "is_in_hit_stun": int(player_state.is_in_hit_stun),
             "sprite_shake_position": player_state.sprite_shake_position,
-            "max_sprite_shake_frame": player_state.max_sprite_shake_frame / 10,
+            "max_sprite_shake_frame": player_state.max_sprite_shake_frame / NormalizationConstants.meaningful_sprite_shake_frame,
             "is_face_right": int(player_state.is_face_right),
             "current_frame_advantage": player_state.current_frame_advantage
-            / 10,
-            # The below features leak some information about the opponent!
+            / NormalizationConstants.meaningful_frame_advantage,
+
+            # Begin privileged features
             "would_next_forward_input_dash": int(
                 player_state.would_next_forward_input_dash
             ),

--- a/footsiesgym/footsies/encoder.py
+++ b/footsiesgym/footsies/encoder.py
@@ -82,22 +82,22 @@ class FootsiesEncoder:
 
         # Opponent states that remove privileged features
         # Remove privileged features from the opponent's state dict then concatenate
-        p1_opponent_state = np.hstack(
-            [p2_encoding[key] for key in p2_encoding if key not in self.privileged_feature_names],
+        p1_well_known_state = np.hstack(
+            [p1_encoding[key] for key in p1_encoding if key not in self.privileged_feature_names],
             dtype=np.float32,
         )
-        p2_opponent_state = np.hstack(
-            [p1_encoding[key] for key in p1_encoding if key not in self.privileged_feature_names],
+        p2_well_known_state = np.hstack(
+            [p2_encoding[key] for key in p2_encoding if key not in self.privileged_feature_names],
             dtype=np.float32,
         )
 
 
         p1_centric_observation = np.hstack(
-            [common_state, p1_encoding_concat, p2_opponent_state]
+            [common_state, p1_encoding_concat, p2_well_known_state]
         )
 
         p2_centric_observation = np.hstack(
-            [common_state, p2_encoding_concat, p1_opponent_state]
+            [common_state, p2_encoding_concat, p1_well_known_state]
         )
 
         return {"p1": p1_centric_observation, "p2": p2_centric_observation}
@@ -187,6 +187,8 @@ class FootsiesEncoder:
                 player_state.special_attack_progress, 1.0
             ),
         }
+
+        print(feature_dict["special_attack_progress"])
 
         if kwargs:
             feature_dict.update(kwargs)

--- a/footsiesgym/footsies/encoder.py
+++ b/footsiesgym/footsies/encoder.py
@@ -23,19 +23,11 @@ class FootsiesEncoder:
 
     observation_size: int = 81
 
-    def __init__(self, observation_delay: int):
-        self._encoding_history = {
-            agent_id: collections.deque(maxlen=int(observation_delay))
-            for agent_id in ["p1", "p2"]
-        }
-        self.observation_delay = observation_delay
+    def __init__(self):
         self._last_common_state: np.ndarray | None = None
 
     def reset(self):
-        self._encoding_history = {
-            agent_id: collections.deque(maxlen=int(self.observation_delay))
-            for agent_id in ["p1", "p2"]
-        }
+        self._last_common_state = None
 
     def encode(
         self,
@@ -65,23 +57,6 @@ class FootsiesEncoder:
             game_state.player2, game_state.frame_count, **kwargs.get("p2", {})
         )
 
-        observation_delay = min(
-            self.observation_delay, len(self._encoding_history["p1"])
-        )
-
-        if observation_delay > 0:
-            p1_delayed_encoding = self._encoding_history["p1"][
-                -observation_delay
-            ]
-            p2_delayed_encoding = self._encoding_history["p2"][
-                -observation_delay
-            ]
-        else:
-            p1_delayed_encoding = copy.deepcopy(p1_encoding)
-            p2_delayed_encoding = copy.deepcopy(p2_encoding)
-
-        self._encoding_history["p1"].append(p1_encoding)
-        self._encoding_history["p2"].append(p2_encoding)
         self._last_common_state = common_state
 
         # Create features dictionary and export to JSON
@@ -99,43 +74,30 @@ class FootsiesEncoder:
         p1_encoding = np.hstack(list(p1_encoding.values()), dtype=np.float32)
         p2_encoding = np.hstack(list(p2_encoding.values()), dtype=np.float32)
 
-        # Concatenate the observations for the delayed encoding
-        p1_delayed_encoding = np.hstack(
-            list(p1_delayed_encoding.values()), dtype=np.float32
-        )
-        p2_delayed_encoding = np.hstack(
-            list(p2_delayed_encoding.values()), dtype=np.float32
-        )
-
         p1_centric_observation = np.hstack(
-            [common_state, p1_encoding, p2_delayed_encoding]
+            [common_state, p1_encoding, p2_encoding]
         )
 
         p2_centric_observation = np.hstack(
-            [common_state, p2_encoding, p1_delayed_encoding]
+            [common_state, p2_encoding, p1_encoding]
         )
 
         return {"p1": p1_centric_observation, "p2": p2_centric_observation}
 
-    def get_last_encoding(self) -> dict[str, np.ndarray]:
-        if self._last_common_state is None:
-            return None
-
-        return {
-            "common_state": self._last_common_state.reshape(-1),
-            "p1": np.hstack(
-                list(self._encoding_history["p1"][-1].values()),
-                dtype=np.float32,
-            ),
-            "p2": np.hstack(
-                list(self._encoding_history["p2"][-1].values()),
-                dtype=np.float32,
-            ),
-        }
-
     def encode_common_state(
         self, game_state: footsies_pb2.GameState
     ) -> np.ndarray:
+        """
+        Encode features that are always the same for both agents. These
+        should be features that are a function of both players' states.
+
+        Currently only encodes the distance between players. 
+
+        :param game_state: The game state to encode
+        :type game_state: footsies_pb2.GameState
+        :return: The encoded common state
+        :rtype: np.ndarray
+        """
         p1_state, p2_state = game_state.player1, game_state.player2
 
         dist_x = (
@@ -165,6 +127,7 @@ class FootsiesEncoder:
 
         TODO(chase): Test mirroring the positions so
             the agent always thinks it's LHS
+        TODO(chase): Make normalizing constants set in a constants class. 
         """
         feature_dict = {
             "player_position_x": player_state.player_position_x / 4.0,

--- a/footsiesgym/footsies/encoder.py
+++ b/footsiesgym/footsies/encoder.py
@@ -145,7 +145,6 @@ class FootsiesEncoder:
 
         TODO(chase): Test mirroring the positions so
             the agent always thinks it's LHS
-        TODO(chase): Make normalizing constants set in a constants class. 
         """
         feature_dict = {
             "player_position_x": player_state.player_position_x / NormalizationConstants.max_x_value,

--- a/footsiesgym/footsies/footsies_env.py
+++ b/footsiesgym/footsies/footsies_env.py
@@ -110,11 +110,11 @@ class FootsiesEnv(env.MultiAgentEnv):
             "p2": False,
         }
 
-    def _determine_port(self, config: dict[Any, Any] | env_context.EnvContext):
-        if isinstance(config, dict):
-            return self._determine_port_from_dict(config)
-        elif isinstance(config, env_context.EnvContext):
+    def _determine_port(self, config: dict[Any, Any] | env_context.EnvContext) -> int:
+        if isinstance(config, env_context.EnvContext):
             return self._determine_port_from_env_context(config)
+        elif isinstance(config, dict):
+            return self._determine_port_from_dict(config)
         else:
             raise TypeError("config must be a dict or env_context.EnvContext")
 

--- a/footsiesgym/footsies/footsies_env.py
+++ b/footsiesgym/footsies/footsies_env.py
@@ -3,6 +3,7 @@ import time
 import numpy as np
 from gymnasium import spaces
 from ray.rllib import env
+import collections
 
 from . import encoder, typing
 import os
@@ -70,16 +71,17 @@ class FootsiesEnv(env.MultiAgentEnv):
 
         self.t: int = 0
         self.max_t: int = config.get("max_t", 1000)
-        self.frame_skip = config.get("frame_skip", 4)
-        observation_delay = config.get("observation_delay", 16)
+        self.frame_skip: int = config.get("frame_skip", 4)
+        self.action_delay_frames: int = config.get("action_delay", 16)
 
         assert (
-            observation_delay % self.frame_skip == 0
-        ), "observation_delay must be divisible by frame_skip"
+            self.action_delay_frames % self.frame_skip == 0
+        ), "action_delay must be divisible by frame_skip"
 
-        self.encoder = encoder.FootsiesEncoder(
-            observation_delay=observation_delay // self.frame_skip
-        )
+        self.action_delay_steps: int = self.action_delay_frames // self.frame_skip
+        self.encoder = encoder.FootsiesEncoder()
+        self._action_queues: dict[typing.AgentID, collections.deque[int]] = None
+        self._reset_action_delay_queues()
 
 
         
@@ -218,19 +220,35 @@ class FootsiesEnv(env.MultiAgentEnv):
         """Ensure cleanup happens when the object is garbage collected."""
         self.close()
 
+    def _reset_action_delay_queues(self):
+        self._action_queues: dict[typing.AgentID, collections.deque[int]] = {
+            agent_id: collections.deque[int] = collections.deque([constants.EnvActions.NONE] * self.action_delay_steps, maxlen=self.action_delay_steps)
+            for agent_id in self.agents
+        }
+    
+    def _validate_action_queues(self):
+        for agent_id in self.agents:
+            assert len(self._action_queues[agent_id]) == self.action_delay_steps, (
+                f"Action queue has the incorrect number of queued actions! "
+                " Observed {len(self._action_queues[agent_id])}, expected {self.action_delay_steps}"
+            )
 
     def get_obs(self, game_state):
         if self.use_build_encoding:
-            encoded_state = self.game.get_encoded_state()
-            encoded_state_dict = {
-                "p1": np.asarray(
-                    encoded_state.player1_encoding, dtype=np.float32
-                ),
-                "p2": np.asarray(
-                    encoded_state.player2_encoding, dtype=np.float32
-                ),
-            }
-            return encoded_state_dict
+            raise NotImplementedError(
+                "Build encoder has not yet integrated action delay! "
+                "Please use the default Python encoder for now."
+            )
+            # encoded_state = self.game.get_encoded_state()
+            # encoded_state_dict = {
+            #     "p1": np.asarray(
+            #         encoded_state.player1_encoding, dtype=np.float32
+            #     ),
+            #     "p2": np.asarray(
+            #         encoded_state.player2_encoding, dtype=np.float32
+            #     ),
+            # }
+            # return encoded_state_dict
         else:
             return self.encoder.encode(game_state)
 
@@ -251,6 +269,8 @@ class FootsiesEnv(env.MultiAgentEnv):
         self.t = 0
         self.game.reset_game()
         self.game.start_game()
+
+        self._reset_action_delay_queues()
 
         self.encoder.reset()
 
@@ -277,10 +297,18 @@ class FootsiesEnv(env.MultiAgentEnv):
         """
         self.t += 1
 
+
+        # Update action queue -> dequeue old actions, enqueue new actions
+        actions_to_execute: dict[typing.AgentID, typing.ActionType] = {}
+        for agent_id in self.agents:
+            actions_to_execute[agent_id] = self._action_queues[agent_id].popleft()
+            self._action_queues[agent_id].append(actions[agent_id])
+
+
         for agent_id in self.agents:
             empty_queue = self.special_charge_queue[agent_id] < 0
             action_is_special_charge = (
-                actions[agent_id] == constants.EnvActions.SPECIAL_CHARGE
+                actions_to_execute[agent_id] == constants.EnvActions.SPECIAL_CHARGE
             )
 
             # Refill the charge queue only if we're not already in a special charge.
@@ -291,12 +319,12 @@ class FootsiesEnv(env.MultiAgentEnv):
 
             if self.special_charge_queue[agent_id] >= 0:
                 self.special_charge_queue[agent_id] -= 1
-                actions[agent_id] = self._convert_to_charge_action(
-                    actions[agent_id]
+                actions_to_execute[agent_id] = self._convert_to_charge_action(
+                    actions_to_execute[agent_id]
                 )
 
-        p1_action = self.game.action_to_bits(actions["p1"], is_player_1=True)
-        p2_action = self.game.action_to_bits(actions["p2"], is_player_1=False)
+        p1_action = self.game.action_to_bits(actions_to_execute["p1"], is_player_1=True)
+        p2_action = self.game.action_to_bits(actions_to_execute["p2"], is_player_1=False)
 
         game_state = self.game.step_n_frames(
             p1_action=p1_action, p2_action=p2_action, n_frames=self.frame_skip
@@ -341,6 +369,7 @@ class FootsiesEnv(env.MultiAgentEnv):
 
         self.last_game_state = game_state
 
+        # ~~~ For debugging game build! ~~~
         # encoded_state = self.game.get_encoded_state()
         # encoded_state_dict = {
         #     "p1": np.asarray(
@@ -354,6 +383,8 @@ class FootsiesEnv(env.MultiAgentEnv):
         # for a_id, ob in observations.items():
         #     matched_obs = np.isclose(ob, encoded_state_dict[a_id]).all()
         #     assert matched_obs
+        # ~~~ END ~~~
+        self._validate_action_queues()
 
         return observations, rewards, terminateds, truncateds, self.get_infos()
 

--- a/footsiesgym/footsies/footsies_env.py
+++ b/footsiesgym/footsies/footsies_env.py
@@ -300,9 +300,12 @@ class FootsiesEnv(env.MultiAgentEnv):
 
         # Update action queue -> dequeue old actions, enqueue new actions
         actions_to_execute: dict[typing.AgentID, typing.ActionType] = {}
-        for agent_id in self.agents:
-            actions_to_execute[agent_id] = self._action_queues[agent_id].popleft()
-            self._action_queues[agent_id].append(actions[agent_id])
+        if self.action_delay_frames == 0:
+            actions_to_execute = actions
+        else:
+            for agent_id in self.agents:
+                actions_to_execute[agent_id] = self._action_queues[agent_id].popleft()
+                self._action_queues[agent_id].append(actions[agent_id])
 
         for agent_id in self.agents:
             empty_queue = self.special_charge_queue[agent_id] < 0

--- a/footsiesgym/footsies/footsies_env.py
+++ b/footsiesgym/footsies/footsies_env.py
@@ -222,7 +222,7 @@ class FootsiesEnv(env.MultiAgentEnv):
 
     def _reset_action_delay_queues(self):
         self._action_queues: dict[typing.AgentID, collections.deque[int]] = {
-            agent_id: collections.deque[int] = collections.deque([constants.EnvActions.NONE] * self.action_delay_steps, maxlen=self.action_delay_steps)
+            agent_id: collections.deque([constants.EnvActions.NONE] * self.action_delay_steps, maxlen=self.action_delay_steps)
             for agent_id in self.agents
         }
     
@@ -303,7 +303,6 @@ class FootsiesEnv(env.MultiAgentEnv):
         for agent_id in self.agents:
             actions_to_execute[agent_id] = self._action_queues[agent_id].popleft()
             self._action_queues[agent_id].append(actions[agent_id])
-
 
         for agent_id in self.agents:
             empty_queue = self.special_charge_queue[agent_id] < 0

--- a/footsiesgym/footsies/footsies_env.py
+++ b/footsiesgym/footsies/footsies_env.py
@@ -111,12 +111,12 @@ class FootsiesEnv(env.MultiAgentEnv):
         }
 
     def _determine_port(self, config: dict[Any, Any] | env_context.EnvContext) -> int:
-        # if isinstance(config, env_context.EnvContext):
-        #     return self._determine_port_from_env_context(config)
-        if isinstance(config, dict):
+        if isinstance(config, env_context.EnvContext):
+            return self._determine_port_from_env_context(config)
+        elif isinstance(config, dict):
             return self._determine_port_from_dict(config)
         else:
-            raise TypeError("config must be a dict")
+            raise TypeError("config must be a dict or EnvContext")
 
     def _determine_port_from_dict(self, config: dict[Any, Any]):
         """Find an available port starting from a base port."""

--- a/footsiesgym/footsies/footsies_env.py
+++ b/footsiesgym/footsies/footsies_env.py
@@ -111,12 +111,12 @@ class FootsiesEnv(env.MultiAgentEnv):
         }
 
     def _determine_port(self, config: dict[Any, Any] | env_context.EnvContext) -> int:
-        if isinstance(config, env_context.EnvContext):
-            return self._determine_port_from_env_context(config)
-        elif isinstance(config, dict):
+        # if isinstance(config, env_context.EnvContext):
+        #     return self._determine_port_from_env_context(config)
+        if isinstance(config, dict):
             return self._determine_port_from_dict(config)
         else:
-            raise TypeError("config must be a dict or env_context.EnvContext")
+            raise TypeError("config must be a dict")
 
     def _determine_port_from_dict(self, config: dict[Any, Any]):
         """Find an available port starting from a base port."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "footsies-gym"
-version = "0.2.0"
+version = "0.2.1"
 description = "A reinforcement learning environment for HiFight's Footsies game"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "footsies-gym"
-version = "0.2.3"
+version = "0.2.4"
 description = "A reinforcement learning environment for HiFight's Footsies game"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "footsies-gym"
-version = "0.1.7"
+version = "0.2.0"
 description = "A reinforcement learning environment for HiFight's Footsies game"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "footsies-gym"
-version = "0.2.4"
+version = "0.2.5"
 description = "A reinforcement learning environment for HiFight's Footsies game"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "footsies-gym"
-version = "0.2.2"
+version = "0.2.3"
 description = "A reinforcement learning environment for HiFight's Footsies game"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "footsies-gym"
-version = "0.2.1"
+version = "0.2.2"
 description = "A reinforcement learning environment for HiFight's Footsies game"
 readme = "README.md"
 license = "MIT"

--- a/scripts/checkpoint_to_onnx.py
+++ b/scripts/checkpoint_to_onnx.py
@@ -7,7 +7,7 @@ from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.utils.test_utils import add_rllib_example_script_args, check
 from ray.rllib.utils.torch_utils import convert_to_torch_tensor
 
-from components import module_repository
+from experimentation.components import module_repository
 
 torch, _ = try_import_torch()
 

--- a/scripts/local_inference.py
+++ b/scripts/local_inference.py
@@ -55,7 +55,6 @@ MAX_FPS = 30
 
 
 def action_from_logits(logits: np.ndarray) -> int:
-    print(logits)
     action_probs = special.softmax(logits.reshape(-1))
     return np.random.choice(len(action_probs), p=action_probs)
 

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -6,7 +6,7 @@ import footsiesgym
 
 if __name__ == "__main__":
 
-    env = footsiesgym.make(config={"max_t": 4000, "frame_skip": 4, "observation_delay": 16, "port": 50051, "headless": False}, launch_binaries=True, platform="linux")
+    env = footsiesgym.make(config={"max_t": 4000, "frame_skip": 4, "action_delay": 0, "port": 50051, "headless": False}, launch_binaries=True, platform="linux")
 
 
     obs, _ = env.reset()

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -1,23 +1,28 @@
 import time
 
 import footsiesgym
-
-
-
-
-
+from footsiesgym.footsies.game import constants
 
 if __name__ == "__main__":
 
-    env = footsiesgym.make(config={"max_t": 4000, "frame_skip": 4, "action_delay": 8, "port": 50051, "headless": False}, launch_binaries=True, platform="linux")
+    env = footsiesgym.make(config={"max_t": 1000, "frame_skip": 4, "action_delay": 8, "port": 50051, "headless": False}, launch_binaries=True, platform="linux")
 
+    # Define the action cycle: 20 NOOP actions followed by 1 SPECIAL_CHARGE
+    action_cycle = [constants.EnvActions.NONE] * 5 + [constants.EnvActions.SPECIAL_CHARGE] # + [constants.EnvActions.NONE] * 20 + [constants.EnvActions.SPECIAL_CHARGE]
+    cycle_step = 0
 
     obs, _ = env.reset()
     while True:
+        # Get the current action from the cycle
+        current_action = action_cycle[cycle_step % len(action_cycle)]
+        
         actions = {
-            agent: env.action_space[agent].sample() for agent in env.agents
+            agent: current_action for agent in env.agents
         }
         observations, rewards, terminateds, truncateds, _ = env.step(actions)
+
+        # Advance to next step in the cycle
+        cycle_step += 1
 
         if truncateds["__all__"] or terminateds["__all__"]:
             obs, _ = env.reset()

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -4,9 +4,12 @@ import footsiesgym
 
 
 
+
+
+
 if __name__ == "__main__":
 
-    env = footsiesgym.make(config={"max_t": 4000, "frame_skip": 4, "action_delay": 0, "port": 50051, "headless": False}, launch_binaries=True, platform="linux")
+    env = footsiesgym.make(config={"max_t": 4000, "frame_skip": 4, "action_delay": 8, "port": 50051, "headless": False}, launch_binaries=True, platform="linux")
 
 
     obs, _ = env.reset()


### PR DESCRIPTION
This PR swaps the environment to use action delay instead of observation delay. 

In the observation delay setting, the agent would view a delayed representation of the opponent state. Action delay simplifies the logic by making the observation represent the exact current state for the focal player and opponent, but selected actions won't be executed for a specified number of frames. In contexts where focal and opponent observations are delayed, action delay is mathematically equivalent. We're altering the domain slightly as the focal state was not delayed. 

If `K` is the number of steps that correspond to our delay, the following describes the overarching change: 
- _Old_: Observe `s_{t-K}` -> execute `a_t`.
- _New_: Observe `s_t` -> execute `a_{t-K}`