### PR TITLE
[Bugfix] Previous Action and Charge Conversion Corrections

### DIFF
--- a/experimentation/experiments/experiment.py
+++ b/experimentation/experiments/experiment.py
@@ -108,7 +108,7 @@ class Experiment:
         policy_observation_space = footsies_env.FootsiesEnv.observation_space[
             "p1"
         ]
-        policy_action_space = footsies_env.FootsiesEnv.action_space["p1"]
+        policy_action_space = footsies_env.FootsiesEnv.get_action_space(use_special_charge_action=True)["p1"]
 
         # Add policy names stored in the ModuleRepository here to evaluate against them
         eval_policies = []
@@ -122,11 +122,12 @@ class Experiment:
                     "frame_skip": 4,
                     "action_delay": 8,
                     "num_envs_per_worker": self.NUM_ENVS_PER_ENV_RUNNER,
-                    "guard_break_reward": 3.0,
+                    "guard_break_reward": 0.0,
                     "win_reward_scaling_coeff": 10.0,
-                    "use_reward_budget": True,
+                    "use_reward_budget": False,
                     "launch_binaries": True,
                     "return_fight_state_in_infos": True,
+                    "use_special_charge_action": True,
                 },
             )
             .api_stack(

--- a/footsiesgym/__init__.py
+++ b/footsiesgym/__init__.py
@@ -11,7 +11,7 @@ from .footsies.footsies_env import FootsiesEnv
 from .footsies import encoder, typing
 from .binary_manager import get_binary_manager
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __all__ = ["FootsiesEnv", "encoder", "typing", "make"]
 
 # Initialize binary manager (but don't download yet - wait until needed)

--- a/footsiesgym/binary_manager.py
+++ b/footsiesgym/binary_manager.py
@@ -274,7 +274,7 @@ class BinaryManager:
                 
                 # Create request with user agent to avoid blocking
                 request = urllib.request.Request(url)
-                request.add_header('User-Agent', 'FootsiesGym/0.4.0')
+                request.add_header('User-Agent', 'FootsiesGym/0.4.1')
                 
                 with urllib.request.urlopen(request, timeout=30) as response:
                     # Check if we got a valid response

--- a/footsiesgym/footsies/encoder.py
+++ b/footsiesgym/footsies/encoder.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from footsiesgym.footsies.game import constants
 from footsiesgym.footsies.game.proto import footsies_service_pb2 as footsies_pb2
-from footsiesgym.footsies.typing import AgentID
+from footsiesgym.footsies.typing import ActionType, AgentID
 
 import dataclasses
 
@@ -38,7 +38,7 @@ class EncoderMethods:
 class FootsiesEncoder:
     """Encoder class to generate observations from the game state"""
 
-    observation_size: int = 85
+    observation_size: int = 86
     privileged_feature_names: list[str] = ["special_attack_progress", "would_next_forward_input_dash", "would_next_backward_input_dash", "previous_action", "is_holding_special_charge"]
 
     def __init__(self):
@@ -50,8 +50,9 @@ class FootsiesEncoder:
     def encode(
         self,
         game_state: footsies_pb2.GameState,
-        prev_actions: dict[AgentID, int],
+        prev_actions: dict[AgentID, ActionType],
         is_charging_special: dict[AgentID, bool],
+        num_actions: int,
         **kwargs,
     ) -> dict[str, Any]:
         """Encodes the game state into observations for all agents.
@@ -71,10 +72,10 @@ class FootsiesEncoder:
         """
         common_state = self.encode_common_state(game_state)
         p1_encoding = self.encode_player_state(
-            game_state.player1, prev_actions["p1"], is_charging_special["p1"], **kwargs.get("p1", {})
+            game_state.player1, prev_actions["p1"], is_charging_special["p1"], num_actions, **kwargs.get("p1", {})
         )
         p2_encoding = self.encode_player_state(
-            game_state.player2, prev_actions["p2"], is_charging_special["p2"], **kwargs.get("p2", {})
+            game_state.player2, prev_actions["p2"], is_charging_special["p2"], num_actions, **kwargs.get("p2", {})
         )
 
         self._last_common_state = common_state
@@ -137,8 +138,9 @@ class FootsiesEncoder:
     def encode_player_state(
         self,
         player_state: footsies_pb2.PlayerState,
-        prev_action: int,
+        prev_action: ActionType,
         holding_special_charge: bool,
+        num_actions: int,
         **kwargs,
     ) -> dict[str, int | float | list]:
         """Encodes the player state into observations.
@@ -191,7 +193,7 @@ class FootsiesEncoder:
             "special_attack_progress": min(
                 player_state.special_attack_progress, 1.0
             ),
-            "previous_action": EncoderMethods.one_hot(prev_action, [i for i in range(len(constants.ACTION_TO_BITS))]),
+            "previous_action": EncoderMethods.one_hot(prev_action, [i for i in range(num_actions)]),
             "is_holding_special_charge": int(holding_special_charge),
         }
 
@@ -202,6 +204,9 @@ class FootsiesEncoder:
 
     def _encode_action_id(self, action_id: int) -> np.ndarray:
         """Encodes the action id into a one-hot vector.
+        Note that the action ID is _not_ the action the agent selects,
+        but rather an integer that corresponds to the action (script) being 
+        executed in the game.
 
         :param action_id: The action id to encode
         :type action_id: int

--- a/footsiesgym/footsies/footsies_env.py
+++ b/footsiesgym/footsies/footsies_env.py
@@ -371,6 +371,7 @@ class FootsiesEnv(env.MultiAgentEnv):
             # Toggle the special charge based on whether or not we're holding special already
             if action_is_special_charge and not holding_special_charge:
                 self._holding_special_charge[agent_id] = True
+                actions_to_execute[agent_id] = self.prev_executed_actions[agent_id]
             elif action_is_special_charge and holding_special_charge:
                 self._holding_special_charge[agent_id] = False
                 actions_to_execute[agent_id] = self.prev_executed_actions[agent_id]
@@ -474,6 +475,20 @@ class FootsiesEnv(env.MultiAgentEnv):
         # ~~~ END: For debugging game build! ~~~
         self._validate_action_queues()
 
+        # ~~~ END: For debugging action queue! ~~~
+
+        # if not self.evaluation:
+        #     print("===== Step:", self.t, "=====")
+        #     print("Selected Action: ", actions["p1"])
+        #     print("Executed Action: ", actions_to_execute["p1"])
+        #     print("Holding Special Charge: ", self._holding_special_charge["p1"])
+        #     print("Action Queue: ", self._action_queues["p1"])
+
+        #     if self.t % 30 == 0:
+        #         import sys
+        #         sys.exit(1)
+        # ~~~ END: For debugging action queue! ~~~
+
         return observations, rewards, terminateds, truncateds, self.get_infos()
 
     def get_infos(self):
@@ -494,6 +509,10 @@ class FootsiesEnv(env.MultiAgentEnv):
         if action == constants.EnvActions.BACK:
             return constants.EnvActions.BACK_ATTACK
         elif action == constants.EnvActions.FORWARD:
+            return constants.EnvActions.FORWARD_ATTACK
+        elif action == constants.EnvActions.BACK_ATTACK:
+            return constants.EnvActions.BACK_ATTACK
+        elif action == constants.EnvActions.FORWARD_ATTACK:
             return constants.EnvActions.FORWARD_ATTACK
         else:
             return constants.EnvActions.ATTACK

--- a/footsiesgym/footsies/footsies_env.py
+++ b/footsiesgym/footsies/footsies_env.py
@@ -4,15 +4,15 @@ import numpy as np
 from gymnasium import spaces
 from ray.rllib import env
 import collections
-from ray.rllib.env import env_context
 
-from . import encoder, typing
+from . import encoder
 import os
 import platform
 import subprocess
-import zipfile
 import portpicker
 
+from footsiesgym.footsies.typing import ActionType, AgentID, ObsType
+from footsiesgym.footsies.game.proto import footsies_service_pb2 as footsies_pb2
 from .game import constants, footsies_game
 from ..binary_manager import get_binary_manager
 
@@ -44,9 +44,9 @@ class FootsiesEnv(env.MultiAgentEnv):
         self.config = config
         self.return_fight_state_in_infos = config.get("return_fight_state_in_infos", False)
         self.use_build_encoding = config.get("use_build_encoding", False)
-        self.agents: list[typing.AgentID] = ["p1", "p2"]
-        self.possible_agents: list[typing.AgentID] = self.agents.copy()
-        self._agent_ids: set[typing.AgentID] = set(self.agents)
+        self.agents: list[AgentID] = ["p1", "p2"]
+        self.possible_agents: list[AgentID] = self.agents.copy()
+        self._agent_ids: set[AgentID] = set(self.agents)
         self.win_reward_scaling_coeff = self.config.get("win_reward_scaling_coeff", 1.0)
         self.guard_break_reward_value = self.config.get("guard_break_reward", 0.0)
         self.use_reward_budget = self.config.get("use_reward_budget", False)
@@ -63,7 +63,8 @@ class FootsiesEnv(env.MultiAgentEnv):
         #  Agent selects:  [SPECIAL_CHARGE, NONE, SPECIAL_CHARGE]
         #  Executed Action: [ATTACK, ATTACK, NONE]
         # The second special charge deactivates the held ATTACK.
-        self.action_space = self.get_action_space(use_special_charge_action=config.get("use_special_charge_action", False))
+        self.action_space: dict[AgentID, spaces.Discrete] = self.get_action_space(use_special_charge_action=config.get("use_special_charge_action", False))
+        self.num_actions: int = self.action_space["p1"].n
 
         self.reward_budget = {agent: self.win_reward_scaling_coeff for agent in self.agents}
 
@@ -81,8 +82,13 @@ class FootsiesEnv(env.MultiAgentEnv):
 
         self.action_delay_steps: int = self.action_delay_frames // self.frame_skip
         self.encoder = encoder.FootsiesEncoder()
-        self._action_queues: dict[typing.AgentID, collections.deque[int]] = None
-        self.prev_actions: dict[typing.AgentID, int] = {agent: constants.EnvActions.NONE for agent in self.agents}
+        self._action_queues: dict[AgentID, collections.deque[int]] = None
+
+        # We track two different previous actions: the last action that was sent to the game server
+        # and the last action that the policy selected. Due to action delay this represents a_{t-K}
+        # and a_{t-1} respectively, where K is the action delay. 
+        self.prev_selected_actions: dict[AgentID, int] = {agent: constants.EnvActions.NONE for agent in self.agents}
+        self.prev_executed_actions: dict[AgentID, int] = {agent: constants.EnvActions.NONE for agent in self.agents}
         self._reset_action_delay_queues()
 
 
@@ -269,7 +275,7 @@ class FootsiesEnv(env.MultiAgentEnv):
         self.close()
 
     def _reset_action_delay_queues(self):
-        self._action_queues: dict[typing.AgentID, collections.deque[int]] = {
+        self._action_queues: dict[AgentID, collections.deque[int]] = {
             agent_id: collections.deque([constants.EnvActions.NONE] * self.action_delay_steps, maxlen=self.action_delay_steps)
             for agent_id in self.agents
         }
@@ -281,7 +287,7 @@ class FootsiesEnv(env.MultiAgentEnv):
                 " Observed {len(self._action_queues[agent_id])}, expected {self.action_delay_steps}"
             )
 
-    def get_obs(self, game_state, prev_actions, is_charging_special: dict[typing.AgentID, bool]):
+    def get_obs(self, game_state: footsies_pb2.GameState, prev_actions: dict[AgentID, ActionType], is_charging_special: dict[AgentID, bool], num_actions: int):
         if self.use_build_encoding:
             raise NotImplementedError(
                 "Build encoder has not yet integrated action delay! "
@@ -298,7 +304,7 @@ class FootsiesEnv(env.MultiAgentEnv):
             # }
             # return encoded_state_dict
         else:
-            return self.encoder.encode(game_state, prev_actions, is_charging_special)
+            return self.encoder.encode(game_state, prev_actions, is_charging_special, num_actions)
 
     def reset(
         self,
@@ -306,13 +312,13 @@ class FootsiesEnv(env.MultiAgentEnv):
         seed: int | None = None,
         options: dict | None = None,
     ) -> tuple[
-        dict[typing.AgentID, typing.ObsType], dict[typing.AgentID, Any]
+        dict[AgentID, ObsType], dict[AgentID, Any]
     ]:
         """Resets the environment to the starting state
         and returns the initial observations for all agents.
 
         :return: Tuple of observations and infos for each agent.
-        :rtype: tuple[dict[typing.AgentID, typing.ObsType], dict[typing.AgentID, Any]]
+        :rtype: tuple[dict[AgentID, ObsType], dict[AgentID, Any]]
         """
         self.t = 0
         self.game.reset_game()
@@ -327,28 +333,28 @@ class FootsiesEnv(env.MultiAgentEnv):
 
         self.last_game_state = self.game.get_state()
 
-        observations = self.get_obs(self.last_game_state, self.prev_actions, self._holding_special_charge)
+        observations = self.get_obs(self.last_game_state, self.prev_selected_actions, self._holding_special_charge, self.num_actions)
 
         return observations, self.get_infos()
 
-    def step(self, actions: dict[typing.AgentID, typing.ActionType]) -> tuple[
-        dict[typing.AgentID, typing.ObsType],
-        dict[typing.AgentID, float],
-        dict[typing.AgentID, bool],
-        dict[typing.AgentID, bool],
-        dict[typing.AgentID, dict[str, Any]],
+    def step(self, actions: dict[AgentID, ActionType]) -> tuple[
+        dict[AgentID, ObsType],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict[str, Any]],
     ]:
         """Step the environment with the provided actions for all agents.
 
         :param actions: Dictionary mapping agent ids to their actions for this step.
-        :type actions: dict[typing.AgentID, typing.ActionType]
+        :type actions: dict[AgentID, ActionType]
         :return: Tuple of observations, rewards, terminates, truncateds and infos for all agents.
-        :rtype: tuple[ dict[typing.AgentID, typing.ObsType], dict[typing.AgentID, float], dict[typing.AgentID, bool], dict[typing.AgentID, bool], dict[typing.AgentID, dict[str, Any]], ]
+        :rtype: tuple[ dict[AgentID, ObsType], dict[AgentID, float], dict[AgentID, bool], dict[AgentID, bool], dict[AgentID, dict[str, Any]], ]
         """
         self.t += 1
 
         # Update action queue -> dequeue old actions, enqueue new actions
-        actions_to_execute: dict[typing.AgentID, typing.ActionType] = {}
+        actions_to_execute: dict[AgentID, ActionType] = {}
         if self.action_delay_frames == 0:
             actions_to_execute = actions
         else:
@@ -367,7 +373,7 @@ class FootsiesEnv(env.MultiAgentEnv):
                 self._holding_special_charge[agent_id] = True
             elif action_is_special_charge and holding_special_charge:
                 self._holding_special_charge[agent_id] = False
-                actions_to_execute[agent_id] = self.prev_actions[agent_id]
+                actions_to_execute[agent_id] = self.prev_executed_actions[agent_id]
 
             if self._holding_special_charge[agent_id]:
                 actions_to_execute[agent_id] = self._convert_to_charge_action(
@@ -380,13 +386,18 @@ class FootsiesEnv(env.MultiAgentEnv):
         game_state = self.game.step_n_frames(
             p1_action=p1_action, p2_action=p2_action, n_frames=self.frame_skip
         )
-        observations = self.get_obs(game_state, actions_to_execute, self._holding_special_charge)
+        observations = self.get_obs(
+            game_state=game_state, 
+            prev_actions=actions, 
+            is_charging_special=self._holding_special_charge, 
+            num_actions=self.num_actions
+        )
 
         terminated = game_state.player1.is_dead or game_state.player2.is_dead
 
 
         rewards = {a_id: 0.0 for a_id in self.agents} 
-        # Apply guard-break reward, if using. 
+        # Apply guard break reward, if using. 
         if self.guard_break_reward_value != 0:
             p1_prev_guard_health = self.last_game_state.player1.guard_health
             p2_prev_guard_health = self.last_game_state.player2.guard_health
@@ -443,9 +454,10 @@ class FootsiesEnv(env.MultiAgentEnv):
         }
 
         self.last_game_state = game_state
-        self.prev_actions = actions_to_execute
+        self.prev_executed_actions = actions_to_execute
+        self.prev_selected_actions = actions
 
-        # ~~~ For debugging game build! ~~~
+        # ~~~ START: For debugging game build! ~~~
         # encoded_state = self.game.get_encoded_state()
         # encoded_state_dict = {
         #     "p1": np.asarray(
@@ -459,7 +471,7 @@ class FootsiesEnv(env.MultiAgentEnv):
         # for a_id, ob in observations.items():
         #     matched_obs = np.isclose(ob, encoded_state_dict[a_id]).all()
         #     assert matched_obs
-        # ~~~ END ~~~
+        # ~~~ END: For debugging game build! ~~~
         self._validate_action_queues()
 
         return observations, rewards, terminateds, truncateds, self.get_infos()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "footsies-gym"
-version = "0.4.0"
+version = "0.4.1"
 description = "A reinforcement learning environment for HiFight's Footsies game"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This PR does a couple things:

- Fixes a bug where the previous action that was passed to the observation was the action to be executed rather than the action that was just selected. We need to represent the previous choice to the policy instead of the most recently executed action. 
- Corrects the conversion of actions to charged actions (previous `BACK_ATTACK` and `FORWARD_ATTACK` were both converted to `ATTACK` instead of being preserved). 
- Special charge will always executed the (potentially converted) previous action. This differs from before where when toggling special charge on, it would execute raw `ATTACK`. Now it converts the previous action to the charged equivalent on the step it is first executed. 